### PR TITLE
Add support for ca65 assembly

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -152,6 +152,7 @@ export class Parser {
             case "clojure":
             case "racket":
             case "lisp":
+            case "ca65":
                 this.delimiters.push(";");
                 this.removeRanges.push(true);
                 break;


### PR DESCRIPTION
ca65 uses the same comment syntax as lisp et al. 

See https://cc65.github.io/doc/ca65.html#ss4.1 for reference.